### PR TITLE
Assess peak log events per minute requirements

### DIFF
--- a/example/log-event-rate-measurer/README.md
+++ b/example/log-event-rate-measurer/README.md
@@ -1,0 +1,10 @@
+The `aggregate.rb` script consumes log4net messages streamed to STDIN, aggregating by hour and minute. 
+
+`process-logs.sh` script fetches logs from S3 and streams them into the aggregation script.  Invoke as follows:
+
+```
+export BASE=~/workspace/elasticsearch-development-flow/examples/log-event-rate-measurer
+mkdir ~/tmp-logs/
+cd ~/tmp-logs/
+$BASE/process-logs.sh "ruby $BASE/aggregate.rb"
+```

--- a/example/log-event-rate-measurer/aggregate.rb
+++ b/example/log-event-rate-measurer/aggregate.rb
@@ -1,0 +1,40 @@
+ #!/usr/bin/env ruby
+require 'date'
+
+aggMinute = {}
+aggHour = {}
+
+ARGF.each_line do | line |
+    # http://stackoverflow.com/questions/2982677/ruby-1-9-invalid-byte-sequence-in-utf-8/8856993#8856993
+    line = line.unpack('C*').pack('U*') if !line.valid_encoding?
+
+    if line =~ /^..... (\d{4}-\d{2}-\d{2} \d{2}:\d{2})/
+        aggMinute[$1] = { :count => 0, :bytes => 0 } unless aggMinute.key? $1
+        aggMinute[$1][:count] += 1
+        aggMinute[$1][:bytes] += line.length
+
+        h = $1[0..12]
+        aggHour[h] = { :count => 0, :bytes => 0 } unless aggHour.key? h
+        aggHour[h][:count] += 1
+        aggHour[h][:bytes] += line.length
+    end
+end
+
+def summarize ( level, data )
+    data
+        .sort_by { | datetime, stats | stats[:count] }
+        .last(96)
+        .reverse_each do | value |
+            puts "#{level}\tcount\t#{value[0]}\t#{value[1][:count]}"
+        end
+
+    data
+        .sort_by { | datetime, stats | stats[:bytes] }
+        .last(96)
+        .reverse_each do | value |
+            puts "#{level}\tbytes\t#{value[0]}\t#{value[1][:bytes]}"
+        end
+end
+
+summarize 'minute', aggMinute
+summarize 'hour', aggHour

--- a/example/log-event-rate-measurer/process-logs.sh
+++ b/example/log-event-rate-measurer/process-logs.sh
@@ -1,0 +1,15 @@
+ #!/usr/bin/env bash
+ 
+# this does `rm *`... make sure you're in the proper directory when running
+for SERVICE in AccountInformationGateway AuthenticationGateway CiConnectGateway ClientPreferenceGateway HedgeGateway InstructionProcessorGateway MarketSearchGateway MessageGateway NewsGateway OrderGateway PriceHistoryGateway SimulationGateway TradingApi WatchlistGateway ; do
+    rm -fr *
+
+    for FILE in $(aws s3 list-objects --bucket=ci-elasticsearch-development-flow --prefix="PPE-Logs/" | grep '"Key": "' | sed -r 's/.*: "([^"]+)",.*$/\1/' | grep $SERVICE/) ; do
+        aws s3 get-object --bucket ci-elasticsearch-development-flow --key "$FILE" `echo $FILE | openssl md5 | cut -c10-`.zip > /dev/null
+    done
+
+    unzip -qq -B '*.zip' 1>/dev/null 2>&1
+    rm *.zip
+
+    cat * | $1 | sed -r "s/(.*)/$SERVICE\t\1/"
+done


### PR DESCRIPTION
The performance tests/assessments have been based on staging environments so far and the production load is going to be significantly higher - to ensure the system can cope, the production peak log events per minute should be known to allow for appropriate test scenarios.

While inquiring the operations team is in progress already via @mrdavidlaing, an alternative approach would be to deduce this from a relevant log dataset - however, given this sensitive data can't leave the firewall,  a respective analysis script for BTF usage is required.
