### PR TITLE
Monitor elasticsearch and redis statistics

### DIFF
--- a/.build/dev_server/extra.sh
+++ b/.build/dev_server/extra.sh
@@ -20,9 +20,24 @@ if ! (which aws 1>/dev/null 2>&1) ; then
 fi
 
 if ! (which collectd 1>/dev/null 2>&1) ; then
-    sudo apt-get install -y collectd
-    sudo service collectd stop
-    sudo sh -c 'sed -i "s/#Interval 10/Interval 60/" /etc/collectd/collectd.conf'
-    sudo rm -fr /var/lib/collectd/rrd/*
-    sudo service collectd start
+    sudo /bin/bash <<EOF
+        apt-get install -y collectd
+        service collectd stop
+        sed -i "s/#Interval 10/Interval 60/" /etc/collectd/collectd.conf
+        mkdir -p /opt/collectd/lib/collectd/plugins/python
+
+        (
+            echo '<LoadPlugin python>'
+            echo '    Globals true'
+            echo '</LoadPlugin>'
+            echo ''
+            echo '<Plugin python>'
+            echo '    ModulePath "/opt/collectd/lib/collectd/plugins/python"'
+            echo '    # python-placeholder'
+            echo '</Plugin>'
+        ) >> /etc/collectd/collectd.conf
+    
+        rm -fr /var/lib/collectd/rrd/*
+        service collectd start
+EOF
 fi

--- a/example/stats-viewer/index.html
+++ b/example/stats-viewer/index.html
@@ -123,6 +123,28 @@
                 createChart(
                     {
                         title : {
+                            text : 'collectd/process-state'
+                        },
+                        plotOptions : {
+                            areaspline : {
+                                stacking : 'normal'
+                            }
+                        },
+                        series : Array.map(
+                            [ 'paging', 'zombies', 'stopped', 'running', 'sleeping', 'blocked' ],
+                            function (v) {
+                                return {
+                                    name : v,
+                                    data : gatherStats('collectd/processes/ps_state-' + v + '/value')
+                                };
+                            }
+                        )
+                    }
+                );
+
+                createChart(
+                    {
+                        title : {
                             text : 'collectd/memory'
                         },
                         plotOptions : {
@@ -496,6 +518,291 @@
                         );
                     }
                 );
+
+                if ('collectd/elasticsearch-elasticsearch/bytes-jvm.mem.heap-committed/value' in stats) {
+                    // looks like a useful elasticsearch node
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/jvm/heap'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'bytes'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'committed',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/bytes-jvm.mem.heap-committed/value')
+                                },
+                                {
+                                    name : 'used',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/bytes-jvm.mem.heap-used/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/jvm/non-heap'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'bytes'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'committed',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/bytes-jvm.mem.non-heap-committed/value')
+                                },
+                                {
+                                    name : 'used',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/bytes-jvm.mem.non-heap-used/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/jvm/threads'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'count'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'threads',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/gauge-jvm.threads.count/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/jvm/gc'
+                            },
+                            yAxis : [
+                                {
+                                    title : {
+                                        text : 'milliseconds'
+                                    }
+                                },
+                                {
+                                    title : {
+                                        text : 'count'
+                                    },
+                                    opposite : true
+                                }
+                            ],
+                            series : [
+                                {
+                                    name : 'time',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/counter-jvm.gc.time/value')
+                                },
+                                {
+                                    name : 'count',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/counter-jvm.gc.count/value'),
+                                    yAxis : 1
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/process/open-file-descriptors'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'count'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'fds',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/gauge-process.open_file_descriptors/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/indices/search/query'
+                            },
+                            yAxis : [
+                                {
+                                    title : {
+                                        text : 'milliseconds'
+                                    }
+                                },
+                                {
+                                    title : {
+                                        text : 'count'
+                                    },
+                                    opposite : true
+                                }
+                            ],
+                            series : [
+                                {
+                                    name : 'time',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/counter-indices.search.query-time/value')
+                                },
+                                {
+                                    name : 'total',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/counter-indices.search.query-total/value'),
+                                    yAxis : 1
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/indices/indexing/index'
+                            },
+                            yAxis : [
+                                {
+                                    title : {
+                                        text : 'milliseconds'
+                                    }
+                                },
+                                {
+                                    title : {
+                                        text : 'count'
+                                    },
+                                    opposite : true
+                                }
+                            ],
+                            series : [
+                                {
+                                    name : 'time',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/counter-indices.indexing.index-time/value')
+                                },
+                                {
+                                    name : 'total',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/counter-indices.indexing.index-total/value'),
+                                    yAxis : 1
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/elasticsearch/indices/docs'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'count'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'docs',
+                                    data : gatherStats('collectd/elasticsearch-elasticsearch/gauge-indices.docs.count/value')
+                                }
+                            ]
+                        }
+                    );
+                }
+
+                if ('collectd/elasticsearch-elasticsearch/bytes-jvm.mem.heap-committed/value' in stats) {
+                    // looks like a useful redis node
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/redis/clients'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'count'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'connected',
+                                    data : gatherStats('collectd/redis_info/gauge-connected_clients/value')
+                                },
+                                {
+                                    name : 'blocked',
+                                    data : gatherStats('collectd/redis_info/gauge-blocked_clients/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/redis/commands'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'count'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'commands',
+                                    data : gatherStats('collectd/redis_info/counter-commands_processed/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/redis/changes-since-save'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'count'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'changes',
+                                    data : gatherStats('collectd/redis_info/gauge-changes_since_last_save/value')
+                                }
+                            ]
+                        }
+                    );
+
+                    createChart(
+                        {
+                            title : {
+                                text : 'collectd/redis/memory'
+                            },
+                            yAxis : {
+                                title : {
+                                    text : 'bytes'
+                                }
+                            },
+                            series : [
+                                {
+                                    name : 'used',
+                                    data : gatherStats('collectd/redis_info/bytes-used_memory/value')
+                                }
+                            ]
+                        }
+                    );
+                }
             }
         </script>
     </body>

--- a/srv/elasticsearch/provision.sh
+++ b/srv/elasticsearch/provision.sh
@@ -31,3 +31,21 @@ if [ ! -e $APP_VENDOR_DIR/elasticsearch/plugins/cloud-aws ] ; then
     ./bin/plugin -install elasticsearch/elasticsearch-cloud-aws/1.12.0
     popd
 fi
+
+
+#
+# sudo-dependent
+#
+
+sudo /bin/bash <<EOF
+    if ! grep 'Import elasticsearch' /etc/collectd/collectd.conf ; then
+        wget -qO /opt/collectd/lib/collectd/plugins/python/elasticsearch.py 'https://raw.github.com/phobos182/collectd-elasticsearch/master/elasticsearch.py'
+        sed -ri 's@(^    # python-placeholder)@\1\n\
+    Import "elasticsearch"\n\
+    <Module elasticsearch>\n\
+        Host "$APP_CONFIG_ES_IPADDRESS"\n\
+        Port 9200\n\
+    </Module>@' /etc/collectd/collectd.conf
+        service collectd restart
+    fi
+EOF

--- a/srv/redis/provision.sh
+++ b/srv/redis/provision.sh
@@ -21,3 +21,22 @@ if [ ! -e $APP_VENDOR_DIR/redis ] ; then
 fi
 
 echo "redis:$($APP_VENDOR_DIR/redis/src/redis-server -v | awk -F '=' '/v=/ { print $2 }')"
+
+
+#
+# sudo-dependent
+#
+
+sudo /bin/bash <<EOF
+    if ! grep 'Import redis_info' /etc/collectd/collectd.conf ; then
+        wget -qO /opt/collectd/lib/collectd/plugins/python/redis_info.py 'https://raw.github.com/powdahound/redis-collectd-plugin/master/redis_info.py'
+        sed -ri 's@(^    # python-placeholder)@\1\n\
+    Import "redis_info"\n\
+    <Module redis_info>\n\
+        Host "$APP_CONFIG_REDIS_IPADDRESS"\n\
+        Port 6379\n\
+        Verbose false\n\
+    </Module>@' /etc/collectd/collectd.conf
+        service collectd restart
+    fi
+EOF


### PR DESCRIPTION
It adds the following raw metrics and a few useful charts to the stats-viewer. Most notably, this will help monitor import and indexing rates.
- `collectd/elasticsearch-elasticsearch/bytes-indices.store.size/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.indexing.index-total/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.get.missing-total/value`
- `collectd/elasticsearch-elasticsearch/counter-jvm.gc.time/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.search.fetch-time/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.search.query-time/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.search.query-total/value`
- `collectd/elasticsearch-elasticsearch/gauge-http.total_open/value`
- `collectd/elasticsearch-elasticsearch/counter-transport.rx.count/value`
- `collectd/elasticsearch-elasticsearch/gauge-http.current_open/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.indexing.delete-total/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.get.exists-time/value`
- `collectd/elasticsearch-elasticsearch/gauge-transport.server_open/value`
- `collectd/elasticsearch-elasticsearch/gauge-indices.search.query-current/value`
- `collectd/elasticsearch-elasticsearch/gauge-jvm.threads.count/value`
- `collectd/elasticsearch-elasticsearch/counter-transport.tx.count/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.indexing.index-time/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.get.missing-time/value`
- `collectd/elasticsearch-elasticsearch/bytes-jvm.mem.non-heap-used/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.get.time/value`
- `collectd/elasticsearch-elasticsearch/gauge-indices.docs.count/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.search.fetch-total/value`
- `collectd/elasticsearch-elasticsearch/gauge-process.open_file_descriptors/value`
- `collectd/elasticsearch-elasticsearch/gauge-jvm.threads.peak/value`
- `collectd/elasticsearch-elasticsearch/bytes-jvm.mem.heap-used/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.indexing.delete-time/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.search.fetch-current/value`
- `collectd/elasticsearch-elasticsearch/bytes-jvm.mem.non-heap-committed/value`
- `collectd/elasticsearch-elasticsearch/bytes-jvm.mem.heap-committed/value`
- `collectd/elasticsearch-elasticsearch/bytes-transport.tx.size/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.docs.deleted/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.get.total/value`
- `collectd/elasticsearch-elasticsearch/bytes-transport.rx.size/value`
- `collectd/elasticsearch-elasticsearch/counter-indices.get.exists-total/value`
- `collectd/elasticsearch-elasticsearch/counter-jvm.gc.count/value`
- `collectd/redis_info/gauge-uptime_in_seconds/value`
- `collectd/redis_info/gauge-evicted_keys/value`
- `collectd/redis_info/gauge-connected_clients/value`
- `collectd/redis_info/gauge-db0-keys/value`
- `collectd/redis_info/gauge-blocked_clients/value`
- `collectd/redis_info/counter-commands_processed/value`
- `collectd/redis_info/bytes-used_memory/value`
- `collectd/redis_info/gauge-changes_since_last_save/value`
- `collectd/redis_info/counter-connections_recieved/value`
- `collectd/redis_info/gauge-connected_slaves/value`

It uses: [phobos182/collectd-elasticsearch](https://github.com/phobos182/collectd-elasticsearch) and [powdahound/redis-collectd-plugin](https://github.com/powdahound/redis-collectd-plugin).
