### PR TITLE
vagrant up fails:  /app/app/bin/default-app-dir: /bin/bash^M: bad interpreter: No such file or directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Declare files that will always have LF line endings on checkout.
 *.sh text eol=lf
+bin/* text eol=lf


### PR DESCRIPTION
On Windows, in master branch, after `vagrant destroy` `vagrant up` fails with:

```
pv:1.2.0
/tmp/vagrant-shell: /app/app/bin/default-app-dir: /bin/bash^M: bad interpreter: No such file or directory
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

chmod +x /tmp/vagrant-shell && /tmp/vagrant-shell
```
