### PR TITLE
Add ci_log4net timezone configuration support

### DIFF
--- a/srv/logstash/config/common.conf.erb
+++ b/srv/logstash/config/common.conf.erb
@@ -75,6 +75,21 @@ filter {
     }
 <% end %>
 
+    alter {
+        type => "ci_log4net"
+        coalesce => [
+            "@source_tz",
+            "%{@source_tz}",
+            # NOTE! this is applying a business-specific non-UTC timezone
+            "+01:00"
+        ]
+    }
+
+    mutate {
+        type => "ci_log4net"
+        add_field => [ "datetime_tz", "%{datetime}%{@source_tz}" ]
+    }
+
     #
     # specify the date field names for various types
     #
@@ -116,23 +131,19 @@ filter {
         match => [ "time", "YYYY-MM-dd HH:mm:ss.SSSSSSS" ]
     }
 
-    #default real_tzoffset to +01:00
-    alter {
-        type => "ci_log4net"
-        coalesce => [
-             "real_tzoffset", "%{real_tzoffset}", "+01:00"
-        ]
-    }
-
     date {
         type => "ci_log4net"
-        match => [ "datetime", "YYYY-MM-dd HH:mm:ss,SSS%{real_tzoffset} " ]
+        match => [ "datetime_tz", "YYYY-MM-dd HH:mm:ss,SSSZ" ]
     }
-
 
     #
     # type-casting for more advanced searches
     #
+
+    mutate {
+        type => "ci_log4net"
+        remove => [ "datetime_tz" ]
+    }
 
     mutate {
         convert => [ "status", "integer" ]

--- a/srv/logstash/test/ci_log4net.rb
+++ b/srv/logstash/test/ci_log4net.rb
@@ -18,8 +18,8 @@ class SimpleCiLog4netTest < Test::Unit::TestCase
       '@fields.level:ERROR'
     )
 
-    assert_equal '2013-06-21 08:00:00,012', res['hits']['hits'][0]['_source']['@timestamp'][0]
-    assert_equal '2013-06-21 08:00:00,012', res['hits']['hits'][0]['_source']['@fields']['datetime'][0]
+    assert_equal '2013-06-21T08:00:00.012Z', res['hits']['hits'][0]['_source']['@timestamp']
+    assert_equal '2013-06-21 09:00:00,012', res['hits']['hits'][0]['_source']['@fields']['datetime'][0]
   end
 
   def test_no_events_inferred_today


### PR DESCRIPTION
This adds `@source_tz` to log messages, currently defaulting it to `+01:00` if it's not specified. This means:
- log shippers can specify `@source_tz` dynamically/statically;
- raw log messages are not manipulated;
- the timezone used for adjustments remain alongside the log message;
- the table panel may appear to have time discrepancies (i.e. the `@timestamp` says `2013-06-21T08:00:00.012Z`, but the `@message` has `2013-06-21 09:00:00,012`).

In practice, the message:

```
ERROR 2013-06-21 09:00:00,012 Margin_3 MarginRealTime MC - CA:400220534 MI:15.181891073288527743228387400 Ind:False MCP:True MCATP:False
```

Is parsed as:

```
{
    "@fields": {
        "datetime": [
            "2013-06-21 09:00:00,012"
        ], 
        "level": [
            "ERROR"
        ], 
        "logger": [
            "MarginRealTime"
        ], 
        "message": [
            "MC - CA:400220534 MI:15.181891073288527743228387400 Ind:False MCP:True MCATP:False"
        ], 
        "thread": [
            "Margin_3"
        ]
    }, 
    "@message": "ERROR 2013-06-21 09:00:00,012 Margin_3 MarginRealTime MC - CA:400220534 MI:15.181891073288527743228387400 Ind:False MCP:True MCATP:False", 
    "@source": "stdin://ip-10-166-60-136/", 
    "@source_host": "ip-10-166-60-136", 
    "@source_path": "/", 
    "@source_tz": "+01:00", 
    "@tags": [], 
    "@timestamp": "2013-06-21T08:00:00.012Z", 
    "@type": "ci_log4net"
}
```
