### PR TITLE
Expose elasticsearch via localhost:9200 on dev_server

### DIFF
--- a/.build/dev_server/provision.sh
+++ b/.build/dev_server/provision.sh
@@ -35,8 +35,7 @@ echo '$APP_USER hard nofile 64000' >> /etc/security/limits.d/$APP_USER.conf
 
 /app/app/bin/default-app-dir > /app/.env
 echo "export APP_USER='$APP_USER'" >> /app/.env
-echo "export APP_CONFIG_ES_IPADDRESS='127.0.0.1'" >> /app/.env
-echo "export APP_CONFIG_ES_IPADDRESS='127.0.0.1'" >> /app/.env
+echo "export APP_CONFIG_ES_IPADDRESS='0.0.0.0'" >> /app/.env
 echo 'export APP_CONFIG_REDIS_IPADDRESS="127.0.0.1"' >> /app/.env
 echo 'export APP_CONFIG_REDIS_KEY=logstash' >> /app/.env
 echo 'export APP_CONFIG_IMPORTQUEUE_KEY=importqueue' >> /app/.env

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu-precise-server-amd64"
   config.vm.box_url = "http://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-vagrant-amd64-disk1.box"
 
-  config.vm.network :forwarded_port, guest: 80, host: 4567
+  config.vm.network :forwarded_port, guest: 80, host: 4567   # kibana (with proxied readonly ES calls)
+  config.vm.network :forwarded_port, guest: 9200, host: 9200 # elasticsearch
 
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", "1024"]


### PR DESCRIPTION
Useful when writing bots that need full access to elastic search functionality to do things like deleting
