### PR TITLE
Reconfigure SNS notification targets for Auto Scaling progress

### DIFF
--- a/.build/aws/cloudformation/composite-ci-r53.template
+++ b/.build/aws/cloudformation/composite-ci-r53.template
@@ -6,6 +6,10 @@
             "Type" : "String",
             "Description" : "An SNS Topic ARN to publish stability alarms to."
         },
+        "AutoScalingTopicArn" : {
+            "Type" : "String",
+            "Description" : "An SNS Topic ARN to publish Auto Scaling notifications to."
+        },
         "AvailabilityZone": {
             "Type": "String",
             "Description": "Availability Zone (AZ) to start the cluster in.",
@@ -318,7 +322,7 @@
                     ]
                 },
                 "Parameters" : {
-                    "AlarmTopicArn"         : { "Ref" : "AlarmTopicArn" },
+                    "AutoScalingTopicArn"         : { "Ref" : "AutoScalingTopicArn" },
                     "ClusterName"           : { "Ref" : "ClusterName" },
                     "CostCentre"            : { "Ref" : "CostCentre" },
                     "ElasticsearchHost"     : { "Ref" : "DnsSrvPrivateElasticsearch" },

--- a/.build/aws/cloudformation/group-logstash-default.template
+++ b/.build/aws/cloudformation/group-logstash-default.template
@@ -2,7 +2,7 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "A default logstash parser node auto scaling group.",
     "Parameters": {
-        "AlarmTopicArn": {
+        "AutoScalingTopicArn": {
             "Type": "String",
             "Description": "An SNS ARN for alarms to notify."
         },
@@ -270,7 +270,7 @@
                     "Ref": "GroupMaxSize"
                 },
                 "NotificationConfiguration" : {
-                    "TopicARN" : { "Ref" : "AlarmTopicArn" },
+                    "TopicARN" : { "Ref" : "AutoScalingTopicArn" },
                     "NotificationTypes" : [
                         "autoscaling:TEST_NOTIFICATION",
                         "autoscaling:EC2_INSTANCE_LAUNCH",


### PR DESCRIPTION
This last minute change addresses https://github.com/cityindex/logsearch/issues/241 in conjunction with https://github.com/cityindex/logsearch-config/issues/43.

@mrdavidlaing - the changes are trivial, but effectively untested, so I'll leave the merge decision up to you (i.e. postponing 'til the next deployment is no issue and will just retain a bit more alarm noise for a few days, eventually).
