### PR TITLE
Amend CloudWatch alarm actions for EC2 status checks

### DIFF
--- a/.build/aws/cloudformation/node-es-ebs-default.template
+++ b/.build/aws/cloudformation/node-es-ebs-default.template
@@ -384,6 +384,16 @@
                     {
                         "Ref": "AlarmTopicArn"
                     }
+                ],
+                "InsufficientDataActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "OKActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
                 ]
             }
         },

--- a/.build/aws/cloudformation/node-es-ephemeral-default.template
+++ b/.build/aws/cloudformation/node-es-ephemeral-default.template
@@ -290,6 +290,16 @@
                     {
                         "Ref": "AlarmTopicArn"
                     }
+                ],
+                "InsufficientDataActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "OKActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
                 ]
             }
         },

--- a/.build/aws/cloudformation/node-redis-default.template
+++ b/.build/aws/cloudformation/node-redis-default.template
@@ -288,6 +288,16 @@
                     {
                         "Ref": "AlarmTopicArn"
                     }
+                ],
+                "InsufficientDataActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "OKActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
                 ]
             }
         },


### PR DESCRIPTION
This implements #274 - the change is trivial, so it is more about deciding on the desired notification configuration (see #274 for a discussion).

@dpb587, @mrdavidlaing - this is a merge candidate, I vote for including this as is.
