### PR TITLE
Add environment handling

### DIFF
--- a/.build/aws/cloudformation/composite-ci-r53.template
+++ b/.build/aws/cloudformation/composite-ci-r53.template
@@ -157,6 +157,16 @@
             "Default": "https://s3.amazonaws.com/ci-elasticsearch-development-flow/aws-cloudformation/master"
         }
     },
+    "Conditions": {
+        "IsLiveEnvironment": {
+            "Fn::Equals": [
+                {
+                    "Ref": "CostCentre"
+                },
+                "logsearch-live"
+            ]
+        }
+    },
     "Resources": {
         "SecurityGroup0": {
             "Type": "AWS::CloudFormation::Stack",
@@ -482,7 +492,17 @@
                 "Dimensions": [
                     {
                         "Name": "ClusterName",
-                        "Value" : { "Ref" : "ClusterName" }
+                        "Value": {
+                            "Fn::If": [
+                                "IsLiveEnvironment",
+                                {
+                                    "Ref": "ClusterName"
+                                },
+                                {
+                                    "Ref": "AWS::StackName"
+                                }
+                            ]
+                        }
                     }
                 ],
                 "Statistic": "Average",
@@ -530,7 +550,17 @@
                 "Dimensions": [
                     {
                         "Name": "ClusterName",
-                        "Value" : { "Ref" : "ClusterName" }
+                        "Value": {
+                            "Fn::If": [
+                                "IsLiveEnvironment",
+                                {
+                                    "Ref": "ClusterName"
+                                },
+                                {
+                                    "Ref": "AWS::StackName"
+                                }
+                            ]
+                        }
                     }
                 ],
                 "Statistic": "Average",


### PR DESCRIPTION
This aims to seed/address #255 - rather than introducing a dedicated `Environment` parameter, I simply base the condition `IsLiveEnvironment` on the `CostCentre` being `logsearch-live` as recently decided - like so it addresses CI specifics within `composite-ci-r53.template`, but doesn't trickle down to the sub templates yet (can be extended once needed, but would require a more explicit `Environment` parameter or a more flexible definition of 'live' in case, e.g. via a map and/or list parameter).

@dpb587 - this addresses the one issue of separate stacks interfering with the live alarm by only using the `ClusterName` parameter for the `ClusterName` dimension value of the latter and `AWS::StackName` for all others - the composition obviously isn't completely transparent like so, maybe you have a better idea to refactor things?
