### PR TITLE
Reconfigure status check alarms

### DIFF
--- a/.build/aws/cloudformation/node-es-ebs-default.template
+++ b/.build/aws/cloudformation/node-es-ebs-default.template
@@ -363,12 +363,12 @@
                 }
             }
         },
-        "Instance0StatusAlarm": {
+        "Instance0InstanceStatusAlarm": {
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
-                "AlarmDescription": "Alarm if the system or instance status checks are failing.",
+                "AlarmDescription": "Alarm if the instance status check is failing.",
                 "Namespace": "AWS/EC2",
-                "MetricName": "StatusCheckFailed",
+                "MetricName": "StatusCheckFailed_Instance",
                 "Dimensions": [
                     {
                         "Name": "InstanceId",
@@ -376,8 +376,42 @@
                     }
                 ],
                 "Statistic": "Maximum",
-                "Period": "300",
-                "EvaluationPeriods": "2",
+                "Period": "60",
+                "EvaluationPeriods": "5",
+                "Threshold": "1",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "AlarmActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "InsufficientDataActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "OKActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ]
+            }
+        },
+        "Instance0SystemStatusAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "AlarmDescription": "Alarm if the system status check is failing.",
+                "Namespace": "AWS/EC2",
+                "MetricName": "StatusCheckFailed_System",
+                "Dimensions": [
+                    {
+                        "Name": "InstanceId",
+                        "Value" : { "Ref" : "Instance0" }
+                    }
+                ],
+                "Statistic": "Maximum",
+                "Period": "60",
+                "EvaluationPeriods": "1",
                 "Threshold": "1",
                 "ComparisonOperator": "GreaterThanOrEqualToThreshold",
                 "AlarmActions": [

--- a/.build/aws/cloudformation/node-es-ephemeral-default.template
+++ b/.build/aws/cloudformation/node-es-ephemeral-default.template
@@ -269,12 +269,12 @@
                 }
             }
         },
-        "Instance0StatusAlarm": {
+        "Instance0InstanceStatusAlarm": {
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
-                "AlarmDescription": "Alarm if the system or instance status checks are failing.",
+                "AlarmDescription": "Alarm if the instance status check is failing.",
                 "Namespace": "AWS/EC2",
-                "MetricName": "StatusCheckFailed",
+                "MetricName": "StatusCheckFailed_Instance",
                 "Dimensions": [
                     {
                         "Name": "InstanceId",
@@ -282,8 +282,42 @@
                     }
                 ],
                 "Statistic": "Maximum",
-                "Period": "300",
-                "EvaluationPeriods": "2",
+                "Period": "60",
+                "EvaluationPeriods": "5",
+                "Threshold": "1",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "AlarmActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "InsufficientDataActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "OKActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ]
+            }
+        },
+        "Instance0SystemStatusAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "AlarmDescription": "Alarm if the system status check is failing.",
+                "Namespace": "AWS/EC2",
+                "MetricName": "StatusCheckFailed_System",
+                "Dimensions": [
+                    {
+                        "Name": "InstanceId",
+                        "Value" : { "Ref" : "Instance0" }
+                    }
+                ],
+                "Statistic": "Maximum",
+                "Period": "60",
+                "EvaluationPeriods": "1",
                 "Threshold": "1",
                 "ComparisonOperator": "GreaterThanOrEqualToThreshold",
                 "AlarmActions": [

--- a/.build/aws/cloudformation/node-redis-default.template
+++ b/.build/aws/cloudformation/node-redis-default.template
@@ -267,12 +267,12 @@
                 }
             }
         },
-        "Instance0StatusAlarm": {
+        "Instance0InstanceStatusAlarm": {
             "Type": "AWS::CloudWatch::Alarm",
             "Properties": {
-                "AlarmDescription": "Alarm if the system or instance status checks are failing.",
+                "AlarmDescription": "Alarm if the instance status check is failing.",
                 "Namespace": "AWS/EC2",
-                "MetricName": "StatusCheckFailed",
+                "MetricName": "StatusCheckFailed_Instance",
                 "Dimensions": [
                     {
                         "Name": "InstanceId",
@@ -280,8 +280,42 @@
                     }
                 ],
                 "Statistic": "Maximum",
-                "Period": "300",
-                "EvaluationPeriods": "2",
+                "Period": "60",
+                "EvaluationPeriods": "5",
+                "Threshold": "1",
+                "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+                "AlarmActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "InsufficientDataActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ],
+                "OKActions": [
+                    {
+                        "Ref": "AlarmTopicArn"
+                    }
+                ]
+            }
+        },
+        "Instance0SystemStatusAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "AlarmDescription": "Alarm if the system status check is failing.",
+                "Namespace": "AWS/EC2",
+                "MetricName": "StatusCheckFailed_System",
+                "Dimensions": [
+                    {
+                        "Name": "InstanceId",
+                        "Value" : { "Ref" : "Instance0" }
+                    }
+                ],
+                "Statistic": "Maximum",
+                "Period": "60",
+                "EvaluationPeriods": "1",
                 "Threshold": "1",
                 "ComparisonOperator": "GreaterThanOrEqualToThreshold",
                 "AlarmActions": [


### PR DESCRIPTION
This implements #285 based on the analysis in https://github.com/cityindex/labs-operations/issues/109 as follows:
- it splits the `StatusCheckFailed` alarm into one for each constituent `StatusCheckFailed_Instance` and `StatusCheckFailed_System` and reconfigures the former 10 minute sensitivity to
  - `StatusCheckFailed_Instance` => _Max = 1 for 5 periods of 60 seconds_ to hide the reachability failure implied in the nightly reboot, i.e. sensitivity for these is going to be 5 minutes going forward
  - `StatusCheckFailed_System` =>  _Max = 1 for 1 periods of 60 seconds_ to provide the earliest possible notification for AWS system failures, i.e. sensitivity for these is going to be 1 minute going forward

:information_source: this is mostly a temporary measure to removed/reduce the current notification noise (and increase alarm sensitivity on the side), which might become partially obsolete or require further adjustments by converting one or more of see affected tiers to Auto Scaling groups (see https://github.com/cityindex/logsearch/issues/149#issuecomment-30311478).

@dpb587 - other than the aforementioned topic, this is ready for review/merge as such.
