### PR TITLE
Remove ruby 1.8 when upgrading to ruby 1.9

### DIFF
--- a/.build/ubuntu-12/provision.sh
+++ b/.build/ubuntu-12/provision.sh
@@ -30,6 +30,9 @@ fi
 echo "curl:\t$(curl --version)" | head -n 1
 
 if [[ ! "$(ruby --version)" =~ "ruby 1.9.3" ]]; then
+  echo "Removing ruby 1.8"
+  sudo apt-get purge libruby1.8 ruby1.8 ruby1.8-dev rubygems1.8 -y
+
   echo "Upgrading ruby to 1.9.1"
   sudo apt-get install ruby1.9.1 ruby1.9.1-dev \
     rubygems1.9.1 irb1.9.1 ri1.9.1 rdoc1.9.1 \
@@ -48,9 +51,6 @@ if [[ ! "$(ruby --version)" =~ "ruby 1.9.3" ]]; then
   # /usr/bin/irb, /usr/bin/ri and man (1) ruby
   sudo update-alternatives --auto ruby
   sudo update-alternatives --auto gem
-
-  echo "Removing ruby 1.8"
-  sudo apt-get remove libruby1.8 ruby1.8 ruby1.8-dev rubygems1.8
 fi
 echo "ruby:\t$(ruby --version)"
 


### PR DESCRIPTION
@sopel and myself bumped into an issue running `rake` with a fresh build of our Vagrant logsearch VMs

```
 vagrant@vagrant-ubuntu-precise-64:/app/app$ rake -T
    rake aborted!
    undefined method `require_relative' for main:Object
    /app/app/srv/logstash/Rakefile:1
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/rake_module.rb:25:in `load'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/rake_module.rb:25:in `load_rakefile'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/default_loader.rb:6:in `load'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:663:in `load_imports'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:596:in `raw_load_rakefile'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:89:in `load_rakefile'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:88:in `load_rakefile'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:72:in `run'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:160:in `standard_exception_handling'
    /var/lib/gems/1.8/gems/rake-10.0.4/lib/rake/application.rb:70:in `run'
    (See full trace by running task with --trace)
```

Turns out that whilst ruby 1.9 was installed, ruby 1.8's gems were still being installed.

see `update-alternatives --query gem`

To fix an existing box run:

```
sudo apt-get remove libruby1.8 ruby1.8 ruby1.8-dev rubygems1.8
sudo gem install bundle --no-ri --no-rdoc
cd /app/app && bundle install
```

This PR removes ruby 1.8 when installing ruby 1.9, and should thus fix the issue for new Vagrant boxes
