### PR TITLE
Add new EC2 M3 instance types

### DIFF
--- a/.build/aws/cloudformation/composite-example-standalone.template
+++ b/.build/aws/cloudformation/composite-example-standalone.template
@@ -69,6 +69,12 @@
             "m2.4xlarge" : {
                 "ElasticsearchHeapSize" : "35G"
             },
+            "m3.medium" : {
+                "ElasticsearchHeapSize" : "2G"
+            },
+            "m3.large" : {
+                "ElasticsearchHeapSize" : "4G"
+            },
             "m3.xlarge" : {
                 "ElasticsearchHeapSize" : "8G"
             },

--- a/.build/aws/cloudformation/group-elasticsearch-default.template
+++ b/.build/aws/cloudformation/group-elasticsearch-default.template
@@ -85,6 +85,8 @@
                 "m2.xlarge",
                 "m2.2xlarge",
                 "m2.4xlarge",
+                "m3.medium",
+                "m3.large",
                 "m3.xlarge",
                 "m3.2xlarge",
                 "c1.medium",

--- a/.build/aws/cloudformation/group-logstash-default.template
+++ b/.build/aws/cloudformation/group-logstash-default.template
@@ -66,6 +66,8 @@
                 "m2.xlarge",
                 "m2.2xlarge",
                 "m2.4xlarge",
+                "m3.medium",
+                "m3.large",
                 "m3.xlarge",
                 "m3.2xlarge",
                 "c1.medium",

--- a/.build/aws/cloudformation/node-es-ebs-default.template
+++ b/.build/aws/cloudformation/node-es-ebs-default.template
@@ -69,6 +69,8 @@
                 "m2.xlarge",
                 "m2.2xlarge",
                 "m2.4xlarge",
+                "m3.medium",
+                "m3.large",
                 "m3.xlarge",
                 "m3.2xlarge",
                 "c1.medium",

--- a/.build/aws/cloudformation/node-es-ephemeral-default.template
+++ b/.build/aws/cloudformation/node-es-ephemeral-default.template
@@ -64,6 +64,8 @@
                 "m2.xlarge",
                 "m2.2xlarge",
                 "m2.4xlarge",
+                "m3.medium",
+                "m3.large",
                 "m3.xlarge",
                 "m3.2xlarge",
                 "c1.medium",

--- a/.build/aws/cloudformation/node-kibana-default.template
+++ b/.build/aws/cloudformation/node-kibana-default.template
@@ -64,6 +64,8 @@
                 "m2.xlarge",
                 "m2.2xlarge",
                 "m2.4xlarge",
+                "m3.medium",
+                "m3.large",
                 "m3.xlarge",
                 "m3.2xlarge",
                 "c1.medium",

--- a/.build/aws/cloudformation/node-redis-default.template
+++ b/.build/aws/cloudformation/node-redis-default.template
@@ -59,6 +59,8 @@
                 "m2.xlarge",
                 "m2.2xlarge",
                 "m2.4xlarge",
+                "m3.medium",
+                "m3.large",
                 "m3.xlarge",
                 "m3.2xlarge",
                 "c1.medium",


### PR DESCRIPTION
This trivial change implements the baseline for  issue #314.

@dpb587, @mrdavidlaing - in light of the obvious benefits I also propose to switch the Redis node from `m1.medium` to `m3.medium` on principle, but given the node is performing just fine and our experience with the initial `c3.large` instance availability I suggest to postpone this 'til next week at least (even though on demand instances shouldn't suffer from availability issues that easily).

Discounting that adjustment, this would be ready for merge and could be reviewed/integrated today already to increase our flexibility.
