### PR TITLE
Drop Double-Logging via log4j and upstart

### DIFF
--- a/srv/elasticsearch/config/logging.yml
+++ b/srv/elasticsearch/config/logging.yml
@@ -17,13 +17,6 @@ appender:
             type: consolePattern
             conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
 
-    file:
-        type: file
-        file: "${path.logs}/process.log"
-        layout:
-            type: pattern
-            conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
-
     request_log_file:
         type: file
         file: "${path.logs}/requests.log"


### PR DESCRIPTION
Anybody have dependencies or objections to dropping the (now) `/app/var/log/elasticsearch/process.log` since it's the same thing as ends up on console stdout/stderr and redirected via upstart to `/app/var/log/elasticsearch-1.log`?
