### PR TITLE
Update CFN to allow starting of i2.2xlarge ES nodes

### DIFF
--- a/.build/aws/cloudformation/composite-example-standalone.template
+++ b/.build/aws/cloudformation/composite-example-standalone.template
@@ -76,6 +76,129 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
+    "RegionMap": {
+      "us-east-1": {
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
+      },
+      "us-west-1": {
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
+      },
+      "eu-west-1": {
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
+      },
+      "ap-northeast-1": {
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
+      },
+      "ap-southeast-2": {
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
+      },
+      "sa-east-1": {
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
+      }
+    },
     "InstanceMemoryMap" : {
       "t1.micro" : {
         "ElasticsearchHeapSize" : "256M"
@@ -163,32 +286,6 @@
       },
       "i2.8xlarge" : {
         "ElasticsearchHeapSize" : "128G"
-      }
-    },
-    "RegionMap": {
-      "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
-      },
-      "us-west-1": {
-        "AMI": "ami-fe002cbb"
-      },
-      "eu-west-1": {
-        "AMI": "ami-ce7b6fba"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
-      },
-      "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
-      },
-      "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
-      },
-      "sa-east-1": {
-        "AMI": "ami-a3da00be"
       }
     }
   },
@@ -373,7 +470,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "InstanceType": {

--- a/.build/aws/cloudformation/group-elasticsearch-default.template
+++ b/.build/aws/cloudformation/group-elasticsearch-default.template
@@ -172,30 +172,127 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
     "RegionMap": {
       "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
       },
       "us-west-1": {
-        "AMI": "ami-fe002cbb"
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
       },
       "eu-west-1": {
-        "AMI": "ami-8c8675fb"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
       },
       "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
       },
       "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
       },
       "sa-east-1": {
-        "AMI": "ami-a3da00be"
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
       }
     }
   },
@@ -329,7 +426,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "IamInstanceProfile": {

--- a/.build/aws/cloudformation/group-logstash-default.template
+++ b/.build/aws/cloudformation/group-logstash-default.template
@@ -144,30 +144,127 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
     "RegionMap": {
       "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
       },
       "us-west-1": {
-        "AMI": "ami-fe002cbb"
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
       },
       "eu-west-1": {
-        "AMI": "ami-ce7b6fba"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
       },
       "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
       },
       "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
       },
       "sa-east-1": {
-        "AMI": "ami-a3da00be"
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
       }
     }
   },
@@ -240,7 +337,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "IamInstanceProfile": {

--- a/.build/aws/cloudformation/node-es-ebs-default.template
+++ b/.build/aws/cloudformation/node-es-ebs-default.template
@@ -139,30 +139,127 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
     "RegionMap": {
       "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
       },
       "us-west-1": {
-        "AMI": "ami-fe002cbb"
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
       },
       "eu-west-1": {
-        "AMI": "ami-ce7b6fba"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
       },
       "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
       },
       "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
       },
       "sa-east-1": {
-        "AMI": "ami-a3da00be"
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
       }
     }
   },
@@ -301,7 +398,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "IamInstanceProfile": {

--- a/.build/aws/cloudformation/node-es-ephemeral-default.template
+++ b/.build/aws/cloudformation/node-es-ephemeral-default.template
@@ -111,30 +111,127 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
     "RegionMap": {
       "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
       },
       "us-west-1": {
-        "AMI": "ami-fe002cbb"
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
       },
       "eu-west-1": {
-        "AMI": "ami-ce7b6fba"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
       },
       "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
       },
       "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
       },
       "sa-east-1": {
-        "AMI": "ami-a3da00be"
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
       }
     }
   },
@@ -252,7 +349,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "IamInstanceProfile": {

--- a/.build/aws/cloudformation/node-kibana-default.template
+++ b/.build/aws/cloudformation/node-kibana-default.template
@@ -111,30 +111,127 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
     "RegionMap": {
       "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
       },
       "us-west-1": {
-        "AMI": "ami-fe002cbb"
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
       },
       "eu-west-1": {
-        "AMI": "ami-ce7b6fba"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
       },
       "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
       },
       "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
       },
       "sa-east-1": {
-        "AMI": "ami-a3da00be"
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
       }
     }
   },
@@ -265,7 +362,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "IamInstanceProfile": {

--- a/.build/aws/cloudformation/node-redis-default.template
+++ b/.build/aws/cloudformation/node-redis-default.template
@@ -114,30 +114,127 @@
     }
   },
   "Mappings": {
+    "InstanceTypeMap": {
+      "t1.micro": {
+        "VirtualizationType": "PV"
+      },
+      "m1.small": {
+        "VirtualizationType": "PV"
+      },
+      "m1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m1.large": {
+        "VirtualizationType": "PV"
+      },
+      "m1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m2.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.medium": {
+        "VirtualizationType": "PV"
+      },
+      "m3.large": {
+        "VirtualizationType": "PV"
+      },
+      "m3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "m3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c1.medium": {
+        "VirtualizationType": "PV"
+      },
+      "c1.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.large": {
+        "VirtualizationType": "PV"
+      },
+      "c3.xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.2xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "c3.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "cc1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cc2.8xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "cg1.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "g2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "hi1.4xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "hs1.8xlarge": {
+        "VirtualizationType": "PV"
+      },
+      "i2.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "i2.8xlarge": {
+        "VirtualizationType": "HVM"
+      }
+    },
     "RegionMap": {
       "us-east-1": {
-        "AMI": "ami-d0f89fb9"
-      },
-      "us-west-2": {
-        "AMI": "ami-70f96e40"
+        "PV": "ami-0b9c9f62",
+        "HVM": "ami-0d9c9f64"
       },
       "us-west-1": {
-        "AMI": "ami-fe002cbb"
+        "PV": "ami-709ba735",
+        "HVM": "ami-729ba737"
+      },
+      "us-west-2": {
+        "PV": "ami-c8bed2f8",
+        "HVM": "ami-ccbed2fc"
       },
       "eu-west-1": {
-        "AMI": "ami-ce7b6fba"
-      },
-      "ap-southeast-1": {
-        "AMI": "ami-64084736"
+        "PV": "ami-51e91b26",
+        "HVM": "ami-5fe91b28"
       },
       "ap-northeast-1": {
-        "AMI": "ami-fe6ceeff"
+        "PV": "ami-45255344",
+        "HVM": "ami-47255346"
+      },
+      "ap-southeast-1": {
+        "PV": "ami-6a7d2c38",
+        "HVM": "ami-687d2c3a"
       },
       "ap-southeast-2": {
-        "AMI": "ami-04ea7a3e"
+        "PV": "ami-51821b6b",
+        "HVM": "ami-57821b6d"
       },
       "sa-east-1": {
-        "AMI": "ami-a3da00be"
+        "PV": "ami-6d9c3f70",
+        "HVM": "ami-6f9c3f72"
       }
     }
   },
@@ -256,7 +353,15 @@
             {
               "Ref": "AWS::Region"
             },
-            "AMI"
+            {
+              "Fn::FindInMap": [
+                "InstanceTypeMap",
+                {
+                  "Ref": "InstanceType"
+                },
+                "VirtualizationType"
+              ]
+            }
           ]
         },
         "IamInstanceProfile": {


### PR DESCRIPTION
From @mrdavidlaing:

@dpb587, these are the CFN changes I made to the existing cityindex.logsearch.io cluster to enable running i2.2xlarge nodes; specifically

live-logsearch-ElasticsearchDaytimeGroup-AFCJ72SHXWNK
live-logsearch-ElasticsearchFulltimeZone1Group-6SYZH3M84SRR
live-logsearch-ElasticsearchFulltimeZone2Group-1TWREYORFN1AZ
However, I'm struggling to identify the correct source files to update. Please can you help.

Also, I had to update the Ubuntu AMI to one based on the HVM hypervisor, since i2.\* nodes don't run on the older PV hypervisor.

This commit is more of a conversation starter than a finished bit of work.
