### PR TITLE
Add new EC2 R3 instance types /issue #365

### DIFF
--- a/.build/aws/cloudformation/composite-example-standalone.template
+++ b/.build/aws/cloudformation/composite-example-standalone.template
@@ -31,7 +31,7 @@
     "InstanceType": {
       "Type": "String",
       "Description": "Instance type for the multi-purpose node.",
-      "Default" : "m1.large",
+      "Default" : "r3.large",
       "AllowedValues": [
         "t1.micro",
         "m1.small",
@@ -45,6 +45,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -112,6 +117,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"
@@ -235,6 +255,21 @@
       },
       "m3.2xlarge" : {
         "ElasticsearchHeapSize" : "15G"
+      },
+      "r3.large" : {
+        "ElasticsearchHeapSize" : "15G"
+      },
+      "r3.xlarge" : {
+        "ElasticsearchHeapSize" : "30500M"
+      },
+      "r3.2xlarge" : {
+        "ElasticsearchHeapSize" : "61G"
+      },
+      "r3.4xlarge" : {
+        "ElasticsearchHeapSize" : "122G"
+      },
+      "r3.8xlarge" : {
+        "ElasticsearchHeapSize" : "244G"
       },
       "c1.medium" : {
         "ElasticsearchHeapSize" : "896M"

--- a/.build/aws/cloudformation/group-elasticsearch-default.template
+++ b/.build/aws/cloudformation/group-elasticsearch-default.template
@@ -83,7 +83,7 @@
       "Description": "An IAM role for the node."
     },
     "InstanceType": {
-      "Default": "m1.large",
+      "Default": "r3.large",
       "Type": "String",
       "Description": "The instance type to create the node on.",
       "AllowedValues": [
@@ -99,6 +99,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -208,6 +213,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"

--- a/.build/aws/cloudformation/group-logstash-default.template
+++ b/.build/aws/cloudformation/group-logstash-default.template
@@ -70,6 +70,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -180,6 +185,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"

--- a/.build/aws/cloudformation/node-es-ebs-default.template
+++ b/.build/aws/cloudformation/node-es-ebs-default.template
@@ -62,7 +62,7 @@
       "Description": "An IAM role for the node."
     },
     "InstanceType": {
-      "Default": "m1.large",
+      "Default": "r3.large",
       "Type": "String",
       "Description": "The instance type to create the node on.",
       "AllowedValues": [
@@ -78,6 +78,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -175,6 +180,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"

--- a/.build/aws/cloudformation/node-es-ephemeral-default.template
+++ b/.build/aws/cloudformation/node-es-ephemeral-default.template
@@ -73,6 +73,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -147,6 +152,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"

--- a/.build/aws/cloudformation/node-kibana-default.template
+++ b/.build/aws/cloudformation/node-kibana-default.template
@@ -73,6 +73,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -147,6 +152,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"

--- a/.build/aws/cloudformation/node-redis-default.template
+++ b/.build/aws/cloudformation/node-redis-default.template
@@ -47,7 +47,7 @@
       "Description": "An IAM role for the node."
     },
     "InstanceType": {
-      "Default": "m1.large",
+      "Default": "r3.large",
       "Type": "String",
       "Description": "The instance type to create the node on.",
       "AllowedValues": [
@@ -63,6 +63,11 @@
         "m3.large",
         "m3.xlarge",
         "m3.2xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
         "c1.medium",
         "c1.xlarge",
         "c3.large",
@@ -150,6 +155,21 @@
       },
       "m3.2xlarge": {
         "VirtualizationType": "PV"
+      },
+      "r3.large": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.2xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.4xlarge": {
+        "VirtualizationType": "HVM"
+      },
+      "r3.8xlarge": {
+        "VirtualizationType": "HVM"
       },
       "c1.medium": {
         "VirtualizationType": "PV"


### PR DESCRIPTION
This implements #365.

@dpb587, @mrdavidlaing - in light of the obvious benefits, I've also changed all ES node defaults from the former `m1.large` to the equally priced but more appropriate `r3.large`, with the exception of `node-es-ephemeral-default.template`, because `r3.large` only features very  small 32GB SSD instance storage.

I've **not** changed the defaults in `composite-ci-r53.template` though, thus this wouldn't affect the current deployments yet.
