### PR TITLE
Update extra.sh  Issue: #369 

### DIFF
--- a/.build/dev_server/extra.sh
+++ b/.build/dev_server/extra.sh
@@ -12,7 +12,7 @@ if ! (which easy_install 1>/dev/null 2>&1) ; then
 fi
 
 if ! (which pip 1>/dev/null 2>&1) ; then
-  curl -O https://raw.github.com/pypa/pip/1.4.1/contrib/get-pip.py
+  curl -O https://raw.githubusercontent.com/pypa/pip/1.4.1/contrib/get-pip.py
   sudo python get-pip.py
 fi
 


### PR DESCRIPTION
As I mentioned in Issue: #369, during a first time install of logsearch the install failed to completed with the following error: 
`python: can't open file 'get-pip.py': [Errno 2] No such file or directory`

When I tested the original link to get-pip.py I confirmed that there is a permanent redirect to the new location of this file.  I verified the `>vagarant populate` completes successfully when I replaced this url on my local machine.  

Outdated URL:  https://raw.github.com/pypa/pip/1.4.1/contrib/get-pip.py
New URL:  https://raw.githubusercontent.com/pypa/pip/1.4.1/contrib/get-pip.py
